### PR TITLE
[UPD] remove SafeMath

### DIFF
--- a/contracts/FeeCenter.sol
+++ b/contracts/FeeCenter.sol
@@ -4,16 +4,13 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "./interface/IFeeCenter.sol";
 import "./utils/Role.sol";
 import "./utils/TransferHelper.sol";
 
 
-
 contract FeeCenter is IFeeCenter, AccessControl, Initializable,Role {
     uint immutable chainId = block.chainid;
-    using SafeMath for uint;
     mapping(uint => mapping (address => gasFee)) chainTokenGasFee;
     //token to vtoken
     mapping(address => address) tokenVault;
@@ -32,7 +29,7 @@ contract FeeCenter is IFeeCenter, AccessControl, Initializable,Role {
 
     function getTokenFee(uint to, address token, uint amount) external view override returns (uint){
         gasFee memory gf =  chainTokenGasFee[to][token];
-        uint fee = amount.mul(gf.proportion).div(10000);
+        uint fee = amount * gf.proportion / 10000;
         if (fee > gf.highest){
             return gf.highest;
         }else if (fee < gf.lowest){
@@ -50,11 +47,11 @@ contract FeeCenter is IFeeCenter, AccessControl, Initializable,Role {
         require(vaultAddress != address(0), "vault not set");
 
         Rate memory vaultRate = distributeRate[0];
-        uint vaultAmount = amount.mul(vaultRate.rate).div(10000);
+        uint vaultAmount = amount * vaultRate.rate / 10000;
         TransferHelper.safeTransfer(token,vaultAddress,vaultAmount);
 
         Rate memory relayerRate = distributeRate[1];
-        uint relayerAmount = amount.mul(relayerRate.rate).div(10000);
+        uint relayerAmount = amount * relayerRate.rate / 10000;
         TransferHelper.safeTransfer(token,relayerRate.feeAddress,relayerAmount);
     }
 

--- a/contracts/MAPBridgeV1.sol
+++ b/contracts/MAPBridgeV1.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
@@ -49,7 +48,6 @@ contract Role is AccessControl{
 
 
 contract MAPBridgeV1 is ReentrancyGuard,Role,Initializable{
-    using SafeMath for uint;
     uint public nonce;
 
     IERC20 public mapToken;
@@ -124,7 +122,7 @@ contract MAPBridgeV1 is ReentrancyGuard,Role,Initializable{
         uint cFee = chainGasFee[toChainId];
         if (cFee > 0) {
             require(mapToken.balanceOf(msg.sender) >= cFee,"balance too low");
-            chainGasFees = chainGasFees.add(cFee);
+            chainGasFees += cFee;
 //            mapToken.transferFrom(msg.sender, address(this), cFee);
             TransferHelper.safeTransferFrom(address(mapToken),msg.sender,address(this),cFee);
         }

--- a/contracts/MAPBridgeV2.sol
+++ b/contracts/MAPBridgeV2.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
@@ -17,7 +16,6 @@ import "./interface/IFeeCenter.sol";
 import "./utils/TransferHelper.sol";
 
 contract MAPBridgeV2 is ReentrancyGuard, Role, Initializable,Pausable {
-    using SafeMath for uint;
     uint public nonce;
 
     IERC20 public mapToken;

--- a/contracts/relayer/Relayer.sol
+++ b/contracts/relayer/Relayer.sol
@@ -337,7 +337,7 @@ contract Relayer is IRelayer, Initializable, Ownable {
         RelayerInfo storage ri = _relayerInfo[_relayer];
         ri.amount = _amount;
 
-        _relayers.add(_relayer);
+        _relayers += _relayer;
     }
 
     function _removeRelayer(address _relayer)

--- a/contracts/test/VToken2.sol
+++ b/contracts/test/VToken2.sol
@@ -3,14 +3,12 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "../vault/VERC20.sol";
 import "../interface/IVault.sol";
 import "../utils/Role.sol";
 
 
 contract VToken2 is VERC20, IVault, Role {
-    using SafeMath for uint;
     uint accrualBlockNumber;
     mapping(address => uint) userStakingAmount;
 
@@ -37,13 +35,13 @@ contract VToken2 is VERC20, IVault, Role {
         }
         uint allCorrespond = correspondBalance();
         uint allCToken = totalSupply();
-        return amount.mul(allCToken).div(allCorrespond);
+        return amount * allCToken / allCorrespond;
     }
 
     function getCorrespondQuantity(uint amount) public view returns (uint){
         uint allCorrespond = correspondBalance();
         uint allCToken = totalSupply();
-        return amount.mul(allCorrespond).div(allCToken);
+        return amount * allCorrespond / allCToken;
     }
 
     function staking(uint amount) external override {

--- a/contracts/vault/VToken.sol
+++ b/contracts/vault/VToken.sol
@@ -3,14 +3,12 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "./VERC20.sol";
 import "../interface/IVault.sol";
 import "../utils/Role.sol";
 
 
 contract VToken is VERC20, IVault, Role {
-    using SafeMath for uint;
     uint accrualBlockNumber;
     mapping(address => uint) userStakingAmount;
 
@@ -37,13 +35,13 @@ contract VToken is VERC20, IVault, Role {
         }
         uint allCorrespond = correspondBalance();
         uint allCToken = totalSupply();
-        return amount.mul(allCToken).div(allCorrespond);
+        return amount * allCToken / allCorrespond;
     }
 
     function getCorrespondQuantity(uint amount) public view returns (uint){
         uint allCorrespond = correspondBalance();
         uint allCToken = totalSupply();
-        return amount.mul(allCorrespond).div(allCToken);
+        return amount * allCorrespond / allCToken;
     }
 
     function staking(uint amount) external override {


### PR DESCRIPTION
Since Solidity 0.8, the overflow/underflow check is implemented on the language level - it adds the validation to the bytecode during compilation.

You don't need the SafeMath library for Solidity 0.8+. ( You're still free to use it in this version) 

It will just perform the same validation twice (once on the language level and once in the SafeMath library).  

This will increase gas usage unnecessarily.

Including SafeMath in >= 0.8.0 is used for custom error checking or if you require a checked / unchecked loop for example but I do not see anything in the code that warrants using SafeMath.

Of course, I could be wrong so feel free to dismiss :P
